### PR TITLE
Fix a nil header reference on GKE connect attempts

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -146,6 +146,7 @@ func (c *cliSession) prepExec() (*http.Request, error) {
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    u,
+		Header: http.Header{},
 	}
 
 	return req, nil


### PR DESCRIPTION
I used this to test out a websocket tunnel and ran into an exception on GKE:

```
$ ./kubectl-execws -it busybox -- ls -lh /
panic: assignment to entry in nil map

goroutine 1 [running]:
net/textproto.MIMEHeader.Set(...)
    /usr/lib/google-golang/src/net/textproto/header.go:22
net/http.Header.Set(...)
    /usr/lib/google-golang/src/net/http/header.go:40
k8s.io/client-go/plugin/pkg/client/auth/exec.(*roundTripper).RoundTrip(0xc0002dc7b0, 0xc000276000)
```

Initializing the header struct fixes it.