### PR TITLE
feat: enable auth plugins use

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -35,8 +35,8 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      #- name: Publish plugin
-      #  uses: rajatjindal/krew-release-bot@v0.0.46
-      #  with:
-      #    krew_template_file: .krew/template.yaml
+
+      - name: Publish plugin
+        uses: rajatjindal/krew-release-bot@v0.0.46
+        with:
+          krew_template_file: .krew/template.yaml

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -35,8 +35,8 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish plugin
-        uses: rajatjindal/krew-release-bot@v0.0.46
-        with:
-          krew_template_file: .krew/template.yaml
+      
+      #- name: Publish plugin
+      #  uses: rajatjindal/krew-release-bot@v0.0.46
+      #  with:
+      #    krew_template_file: .krew/template.yaml

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
Tested manually on oidc enabled cluster
Before:
```sh
% kubectl execws -it -n default aws-cli -- bash
F0314 16:42:14.716047   98614 root.go:166] no Auth Provider found for name "oidc"
```

After:
```sh
% kubectl execws -it -n default aws-cli -- bash
bash-4.4# 
```